### PR TITLE
Fixes for full DMFT cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 compile_commands.json
 doc/cpp2rst_generated
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 compile_commands.json
 doc/cpp2rst_generated
-build/

--- a/python/hartree_fock/lattice.py
+++ b/python/hartree_fock/lattice.py
@@ -70,7 +70,7 @@ class LatticeSolver(object):
 
         self.git_hash = "@PROJECT_GIT_HASH@"
 
-    def solve(self, h_int, N_target=None, mu=None, with_fock=True, one_shot=False, tol=None):
+    def solve(self, h_int, N_target=None, mu=None, with_fock=True, one_shot=False, method='broyden1', tol=None):
         """ Solve for the Hartree Fock self energy using a root finder method.
         The self energy is stored in the ``Sigma_HF`` object of the LatticeSolver instance.
         If a fixed target density ``N_target`` is given, then the chemical potential is calculated
@@ -93,6 +93,10 @@ class LatticeSolver(object):
 
         one_shot : optional, bool
             True if the calcualtion is just one shot and not self consistent. Default is False
+
+        method : optional, string
+            method for root finder. Only used if one_shot=False, see scipy.optimize.root
+            for options. Default : 'broyden1'
 
         tol: optional, float
             Convergence tolerance to pass to root finder
@@ -161,9 +165,9 @@ class LatticeSolver(object):
 
         else:  # self consistent Hartree-Fock
             if tol is None:
-                root_finder = root(target_function, flatten(Sigma_HF_init), method='broyden1')
+                root_finder = root(target_function, flatten(Sigma_HF_init), method=method)
             else:
-                root_finder = root(target_function, flatten(Sigma_HF_init), method='broyden1', tol=tol)
+                root_finder = root(target_function, flatten(Sigma_HF_init), method=method, tol=tol)
             if root_finder['success']:
                 mpi.report('Self Consistent Hartree-Fock converged successfully')
                 self.Sigma_HF = unflatten(root_finder['x'], self.gf_struct, self.force_real)

--- a/python/hartree_fock/utils.py
+++ b/python/hartree_fock/utils.py
@@ -80,68 +80,6 @@ def fermi(e, beta):
     """
     return np.exp(-beta * e * (e > 0))/(1 + np.exp(-beta*np.abs(e)))
 
-def compute_DC_from_density(N_up, N_down, U, J, n_orbitals=5,  method='cFLL', spin_channel=None):
-    """
-    To integrate with SUMK
-    Returns a float for the DC correction  
-
-
-    Parameters
-    ----------
-    N_up : float 
-        Spin up total density
-    
-    N_down : float 
-        Spin down total density
-
-    U : float 
-        U value
-
-    J : float 
-        J value
-
-    n_orbitals : int, default = 5
-        Total number of orbitals
-    
-    spin_channel : string, default = None
-        For which spin channel you are computing the DC correction for, possibilities :
-        -   None: no spin resolved
-        -   up: up channel
-        -   down: down channel
-    
-    method : string, default = 'cFLL' 
-        possibilities:
-        -    cFLL: DC potential from Ryee for spin unpolarized DFT: (DOI: 10.1038/s41598-018-27731-4)
-        -    sFLL: TO IMPLEMENT, same as above for spin polarized DFT
-        -    cAMF: TO IMPLEMENT
-        -    sAMF: TO IMPLEMENT
-        -    cHeld: unpolarized Held's formula as reported in (DOI: 10.1103/PhysRevResearch.2.03308)
-        -    sHeld: polarized Held's formula as reported in (DOI: 10.1103/PhysRevResearch.2.03308)
-    """
-    N_tot = N_up + N_down
-
-    match method:
-        case 'cFLL':
-            DC_val = U * (N_tot-0.5) - J *(N_tot*0.5-0.5)
-
-        case 'sFLL':
-            if spin_channel == 'up':
-                DC_val = U * (N_tot-0.5) - J *(N_up-0.5)
-            elif spin_channel == 'down':
-                DC_val = U * (N_tot-0.5) - J *(N_down-0.5)
-            else:
-                raise ValueError(f"spin_channel set to {spin_channel}, please select 'up' or 'down'")
-        
-        case 'cHeld':
-            U_mean = U * (n_orbitals-1)*(U-2*J)+(n_orbitals-1)*(U-3*J)/(2*n_orbitals-1)
-            DC_val = U_mean * (N_tot-0.5)
-
-    mpi.report(f"DC computed using the {method} method for a value of {DC_val:.6f} eV")
-    if 'Held' in method:
-        mpi.report(f"Held method for {n_orbitals} orbitals, computed U_mean={U_mean:.6f} eV")
-
-    return DC_val
-
 
 def logo():
     logo = """

--- a/python/hartree_fock/utils.py
+++ b/python/hartree_fock/utils.py
@@ -90,3 +90,87 @@ TRIQS: Hartree-Fock solver
 """
     return logo
 
+def compute_DC_from_density(N_tot, U, J, N_spin=None,  n_orbitals=5,  method='sFLL'):
+    """
+    Computes the double counting correction using various methods.
+    For FLL and AMF DC the notations and equations from doi.org/10.1038/s41598-018-27731-4
+    are used, whereas for the Held DC the definitions from doi.org/10.1080/00018730701619647 are used.
+
+    TODO: this is a copy of triqs_dft_tools.util.compute_DC_from_density to remove dependency on dfttools
+    Parameters
+    ----------
+    N_tot : float 
+        Total density of the impurity
+    N_spin : float , default = None
+        Spin density, defaults to N_tot*0.5 if not specified
+    U : float 
+        U value
+    J : float 
+        J value
+    n_orbitals : int, default = 5
+        Total number of orbitals
+    method : string, default = 'cFLL' 
+        possibilities:
+        -    cFLL: DC potential from Ryee for spin unpolarized DFT: (DOI: 10.1038/s41598-018-27731-4)
+        -    sFLL: same as above for spin polarized DFT
+        -    cAMF: around mean field
+        -    sAMF: spin polarized around mean field
+        -    cHeld: unpolarized Held's formula as reported in (DOI: 10.1103/PhysRevResearch.2.03308)
+        -    sHeld: NOT IMPLEMENTED
+    
+    Returns
+    -------
+    List of floats:
+        -   DC_val: double counting potential
+        -   E_val: double counting energy
+
+
+    todo: 
+        - See whether to move this to TRIQS directly instead of dft_tools
+        - allow as input full density matrix to allow orbital dependent DC
+    """
+    if N_spin is not None:
+        N_spin2 = N_tot-N_spin
+        Mag = N_spin - N_spin2
+    L_orbit = (n_orbitals-1)/2
+
+    if method == 'cFLL':
+        E_val = 0.5 * U * N_tot * (N_tot-1) - 0.5 * J * N_tot * (N_tot*0.5-1)
+        DC_val = U * (N_tot-0.5) - J * (N_tot*0.5-0.5)
+
+    elif method == 'sFLL':
+        assert N_spin is not None, "Spin density not given"
+        E_val = 0.5 * U * N_tot * (N_tot-1) - 0.5 * J * N_tot * (N_tot*0.5-1) - 0.25 * J * Mag**2
+        DC_val = U * (N_tot-0.5) - J * (N_spin-0.5)
+
+    elif method == 'cAMF':
+        E_val = +0.5 * U * N_tot ** 2
+        E_val -= 0.25*(U+2*L_orbit*J)/(2*L_orbit+1)*N_tot**2
+        DC_val = U * N_tot - 0.5*(U+2*L_orbit*J)/(2*L_orbit+1)*N_tot
+
+    elif method == 'sAMF':
+        assert N_spin is not None, "Spin density not given"
+        E_val = 0.5 * U * N_tot ** 2
+        E_val -= 0.25*(U+2*L_orbit*J)/(2*L_orbit+1)*N_tot**2
+        E_val -= 0.25*(U+2*L_orbit*J)/(2*L_orbit+1)*Mag**2
+        DC_val = U * N_tot - (U+2*L_orbit*J)/(2*L_orbit+1)*N_spin
+
+    elif method == 'cHeld':
+        # Valid for a Kanamori-type Hamiltonian where U'=U-2J
+        U_mean = (U + (n_orbitals-1)*(U-2*J)+(n_orbitals-1)*(U-3*J))/(2*n_orbitals-1)
+        E_val = 0.5 * U_mean * N_tot * (N_tot - 1)
+        DC_val = U_mean * (N_tot-0.5)
+
+    elif method == 'sHeld':
+        raise ValueError(f"Method sHeld not yet implemented")
+
+    else:
+        raise ValueError(f"DC type {method} not supported")
+
+    mpi.report(f"DC potential computed using the {method} method, V_DC = {DC_val:.6f} eV")
+    mpi.report(f"E_DC using the {method} method, E_DC = {E_val:.6f} eV")
+    if 'Held' in method:
+        mpi.report(f"Held method for {n_orbitals} orbitals, computed U_mean={U_mean:.6f} eV")
+
+    return DC_val, E_val
+

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach(file ${all_h5_ref_files})
 endforeach()
 
 # List of all tests
-set(all_tests LatticeSolver ImpuritySolver)
+set(all_tests LatticeSolver ImpuritySolver Impurity_DC)
 
 foreach(test ${all_tests})
   get_filename_component(test_name ${test} NAME_WE)

--- a/test/python/Impurity_DC.py
+++ b/test/python/Impurity_DC.py
@@ -31,8 +31,7 @@ from triqs.utility.dichotomy import dichotomy
 
 class test_impurity_solver(unittest.TestCase):
 
-    # test that lattice and impurity solvers agree
-    def test_agreement(self):
+    def test_dc(self):
 
         t = 1
         tp = 0.1
@@ -55,9 +54,8 @@ class test_impurity_solver(unittest.TestCase):
         sigma = GfImFreq(beta=beta, n_points=1025, target_shape=[1, 1])
         Sigma = BlockGf(name_list=['up', 'down'], block_list=(sigma, sigma), make_copies=True)
         Gloc = Sigma.copy()
-        # density_required = 1
         mu = 0
-        S = ImpuritySolver(gf_struct=gf_struct, beta=beta, n_iw=1025)
+        S = ImpuritySolver(gf_struct=gf_struct, beta=beta, n_iw=1025, dc=True , dc_U=2.0, dc_J=0.2, dc_type='cFLL',)
 
         converged = False
         while not converged:
@@ -72,28 +70,6 @@ class test_impurity_solver(unittest.TestCase):
             if np.allclose(flatten(Sigma_old), flatten(S.Sigma_HF), rtol=0, atol=1e-6):
                 converged = True
 
-        # test storing to and loading from h5
-        with HDFArchive('impurity_results.h5', 'w') as ar:
-            ar['solver'] = S
-        with HDFArchive('impurity_results.h5', 'r') as ar:
-            S = ar['solver']
-
-        Sigma_imp = S.Sigma_HF
-        mu_imp = mu
-
-        BL = BravaisLattice(units=[(1, 0, 0), (0, 1, 0)])
-        BZ = BrillouinZone(BL)
-        mk = MeshBrZone(BZ, nk)
-        ekup = Gf(mesh=mk, target_shape=[1, 1])
-        ekdn = Gf(mesh=mk, target_shape=[1, 1])
-        ekup << TBL.fourier(mk)
-        ekdn << TBL.fourier(mk)
-        h0_k = BlockGf(name_list=['up', 'down'], block_list=(ekup, ekdn))
-        S = LatticeSolver(h0_k=h0_k, gf_struct=gf_struct, beta=beta)
-        # S.solve(h_int=h_int, N_target=1)
-        S.solve(h_int=h_int)
-        np.testing.assert_allclose(flatten(S.Sigma_HF), flatten(Sigma_imp), rtol=0, atol=1e-4)
-        # np.testing.assert_allclose(S.mu, mu_imp, rtol=0, atol=1e-4)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Changelog:**
* The solver was unstable. The main reason: DC opposes U correction. E_int-E_DC is around an order of magnitude lower than the two. So now the DC for the hartree solver gets computed directly in the solver following the DFT+U philosophy.

* Added a DC interface with solid_dmft to allow all DC tags to work with the new solver
* The solver struggled with restarting: every time the solver is initialized (for example during a restart and during csc), the Sigma inside the solver was initialized to zero, which made the solver unstable. Added an interface to solid_dmft to initialize the Sigma matrix to a given value.
* renamed f -> compute_sigma_hartree

Suggestions/doubts:
* The DC uses a copy of the triqs_dft_tools DC function. We should think about passing the DC as function to the solver. In this way the user can specify its own DC formula.
